### PR TITLE
[Design] list 페이지 Layout 및 퍼블리싱

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,15 +3,8 @@
     "browser": true,
     "es2021": true
   },
-  "extends": [
-    "airbnb",
-    "eslint-config-prettier",
-    "eslint:recommended"
-  ],
-  "plugins": [
-    "eslint-plugin-prettier",
-    "import"
-  ],
+  "extends": ["airbnb", "eslint-config-prettier", "eslint:recommended"],
+  "plugins": ["eslint-plugin-prettier", "import"],
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module"
@@ -24,6 +17,7 @@
       }
     ],
     "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": 0
+    "react/react-in-jsx-scope": 0,
+    "react/prop-types": "off"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "prettier": "^3.2.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.21.2",
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.8",
+        "styled-reset": "^4.5.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -3539,6 +3541,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.2.tgz",
+      "integrity": "sha512-ACXpdMM9hmKZww21yEqWwiLws/UPLhNKvimN8RrYSqPSvB3ov7sLvAcfvaxePeLvccTQKGdkDIhLYApZVDFuKg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -7703,23 +7713,24 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
-      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
+      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
       "dev": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.8.5"
+        "synckit": "^0.8.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://opencollective.com/prettier"
+        "url": "https://opencollective.com/eslint-plugin-prettier"
       },
       "peerDependencies": {
         "@types/eslint": ">=8.0.0",
         "eslint": ">=8.0.0",
+        "eslint-config-prettier": "*",
         "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
@@ -14709,6 +14720,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.2.tgz",
+      "integrity": "sha512-jJcgiwDsnaHIeC+IN7atO0XiSRCrOsQAHHbChtJxmgqG2IaYQXSnhqGb5vk2CU/wBQA12Zt+TkbuJjIn65gzbA==",
+      "dependencies": {
+        "@remix-run/router": "1.14.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.2.tgz",
+      "integrity": "sha512-tE13UukgUOh2/sqYr6jPzZTzmzc70aGRP4pAjG2if0IP3aUT+sBtAKUJh0qMh0zylJHGLmzS+XWVaON4UklHeg==",
+      "dependencies": {
+        "@remix-run/router": "1.14.2",
+        "react-router": "6.21.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -16152,6 +16193,17 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/styled-reset": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.5.2.tgz",
+      "integrity": "sha512-dbAaaVEhweBs2FGfqGBdW6oMcMK8238C2X5KCxBhUQJX92m/QyUfzRADOXhdXiXNkIPELtMCd72YY9eCdORfIw==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">=4.0.0 || >=5.0.0 || >=6.0.0"
+      }
     },
     "node_modules/stylehacks": {
       "version": "5.1.1",

--- a/src/assetes/arrow_left.svg
+++ b/src/assetes/arrow_left.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ic / arrow_left">
+<path id="Polygon 1" d="M10.4615 14L4 8L10.4615 2" stroke="#101010" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/assetes/arrow_right.svg
+++ b/src/assetes/arrow_right.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ic / arrow_right">
+<path id="Polygon 1" d="M5.53846 14L12 8L5.53846 2" stroke="#101010" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,5 +1,5 @@
 import { Outlet } from 'react-router-dom';
-import Header from '../components/Header';
+import Header from './Header';
 
 export default function Layout() {
   return (

--- a/src/components/Paper/Paper.jsx
+++ b/src/components/Paper/Paper.jsx
@@ -1,0 +1,3 @@
+export default function Paper() {
+  return <div>Paper</div>;
+}

--- a/src/components/Paper/Paper.jsx
+++ b/src/components/Paper/Paper.jsx
@@ -3,11 +3,11 @@ import * as S from './Paper.style';
 export default function Paper({ data }) {
   const { name, recentMessages, messageCount, topReactions } = data;
 
-  const messages = recentMessages
+  const threeRecentMessages = recentMessages
     .slice(0, 3)
     .map(e => <S.Image src={e.profileImageURL} key={e.id} alt={e.sender} />);
 
-  const restMessages =
+  const restMessageCount =
     messageCount > 3 ? (
       <S.RestMessageCount>{`+${messageCount - 3}`}</S.RestMessageCount>
     ) : null;
@@ -21,18 +21,16 @@ export default function Paper({ data }) {
 
   return (
     <S.Wrapper>
-      <S.Container>
-        <S.PaperInfo>
-          <S.PaperTitle>To. {name}</S.PaperTitle>
-          <S.ImageBox>
-            {messages}
-            {restMessages}
-          </S.ImageBox>
-          <h3>{messageCount}명이 작성했어요!</h3>
-        </S.PaperInfo>
-        <S.Line />
-        <S.EmojiList>{reactions}</S.EmojiList>
-      </S.Container>
+      <S.PaperInfoBox>
+        <S.PaperTitle>To. {name}</S.PaperTitle>
+        <S.ImageList>
+          {threeRecentMessages}
+          {restMessageCount}
+        </S.ImageList>
+        <h3>{messageCount}명이 작성했어요!</h3>
+      </S.PaperInfoBox>
+      <S.DividedLine />
+      <S.EmojiList>{reactions}</S.EmojiList>
     </S.Wrapper>
   );
 }

--- a/src/components/Paper/Paper.jsx
+++ b/src/components/Paper/Paper.jsx
@@ -1,3 +1,38 @@
-export default function Paper() {
-  return <div>Paper</div>;
+import * as S from './Paper.style';
+
+export default function Paper({ data }) {
+  const { name, recentMessages, messageCount, topReactions } = data;
+
+  const messages = recentMessages
+    .slice(0, 3)
+    .map(e => <S.Image src={e.profileImageURL} key={e.id} alt={e.sender} />);
+
+  const restMessages =
+    messageCount > 3 ? (
+      <S.RestMessageCount>{`+${messageCount - 3}`}</S.RestMessageCount>
+    ) : null;
+
+  const reactions = topReactions.map(reaction => (
+    <S.EmojiCount key={reaction.id}>
+      <p>{reaction.emoji}</p>
+      <p>{reaction.count}</p>
+    </S.EmojiCount>
+  ));
+
+  return (
+    <S.Wrapper>
+      <S.Container>
+        <S.PaperInfo>
+          <S.PaperTitle>To. {name}</S.PaperTitle>
+          <S.ImageBox>
+            {messages}
+            {restMessages}
+          </S.ImageBox>
+          <h3>{messageCount}명이 작성했어요!</h3>
+        </S.PaperInfo>
+        <S.Line />
+        <S.EmojiList>{reactions}</S.EmojiList>
+      </S.Container>
+    </S.Wrapper>
+  );
 }

--- a/src/components/Paper/Paper.style.js
+++ b/src/components/Paper/Paper.style.js
@@ -1,6 +1,8 @@
 import styled, { css } from 'styled-components';
 
 export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
   width: 275px;
   height: 260px;
   flex-shrink: 0;
@@ -11,12 +13,7 @@ export const Wrapper = styled.div`
   padding: 24px;
 `;
 
-export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-export const PaperInfo = styled.div`
+export const PaperInfoBox = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -38,7 +35,7 @@ export const PaperTitle = styled.span`
   letter-spacing: -0.24px;
 `;
 
-export const ImageBox = styled.div`
+export const ImageList = styled.div`
   display: flex;
   gap: -12px;
   margin-left: 12px; // 12만큼 띄우고
@@ -65,11 +62,11 @@ export const RestMessageCount = styled.div`
   justify-content: center;
 `;
 
-export const Line = styled.div`
+export const DividedLine = styled.div`
   width: 100%;
   height: 1px;
   background-color: rgba(0, 0, 0, 0.12);
-  margin-top: 43px;
+  margin-top: 36px;
   margin-bottom: 16px;
 `;
 

--- a/src/components/Paper/Paper.style.js
+++ b/src/components/Paper/Paper.style.js
@@ -1,0 +1,95 @@
+import styled, { css } from 'styled-components';
+
+export const Wrapper = styled.div`
+  width: 275px;
+  height: 260px;
+  flex-shrink: 0;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: var(--Purple-200, #ecd9ff); // 나중에 데이터로부터 받아와야하는 값
+  box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
+  padding: 24px;
+`;
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const PaperInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+export const PaperTitle = styled.span`
+  height: 36px;
+  align-self: stretch;
+  overflow: hidden;
+  color: var(--gray-900);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  font-family: Pretendard-Bold;
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 36px;
+  letter-spacing: -0.24px;
+`;
+
+export const ImageBox = styled.div`
+  display: flex;
+  gap: -12px;
+  margin-left: 12px; // 12만큼 띄우고
+`;
+
+const commonStyles = css`
+  width: 28px;
+  height: 28px;
+  border-radius: 50px;
+  border: 1.5px solid var(--white);
+  background: var(--white);
+  margin-left: -12px; // 12만큼씩 음수 갭 설정
+  color: var(--gray-500);
+`;
+
+export const Image = styled.img`
+  ${commonStyles}
+`;
+
+export const RestMessageCount = styled.div`
+  ${commonStyles}
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Line = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: rgba(0, 0, 0, 0.12);
+  margin-top: 43px;
+  margin-bottom: 16px;
+`;
+
+export const EmojiList = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+`;
+
+export const EmojiCount = styled.div`
+  display: flex;
+  padding: 8px 12px;
+  width: 65px;
+  height: 36px;
+  gap: 10px;
+  border-radius: 32px;
+  background: rgba(0, 0, 0, 0.54);
+
+  p {
+    color: var(--white);
+    font-size: 16px;
+  }
+`;

--- a/src/components/Paper/PaperBox.jsx
+++ b/src/components/Paper/PaperBox.jsx
@@ -1,0 +1,3 @@
+export default function PaperBox({ title }) {
+  return <div>{title}</div>;
+}

--- a/src/components/Paper/PaperBox.jsx
+++ b/src/components/Paper/PaperBox.jsx
@@ -1,3 +1,11 @@
+import PaperContainer from './PaperContainer';
+import * as S from './PaperBox.style';
+
 export default function PaperBox({ title }) {
-  return <div>{title}</div>;
+  return (
+    <S.Container>
+      <span>{title}</span>
+      <PaperContainer />
+    </S.Container>
+  );
 }

--- a/src/components/Paper/PaperBox.style.js
+++ b/src/components/Paper/PaperBox.style.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  margin-top: 50px;
+  flex-direction: column;
+
+  span {
+    font-family: Pretendard-Bold;
+    font-weight: 700;
+    font-size: 24px;
+    margin-bottom: 16px;
+  }
+`;

--- a/src/components/Paper/PaperContainer.jsx
+++ b/src/components/Paper/PaperContainer.jsx
@@ -1,0 +1,3 @@
+export default function PaperContainer() {
+  return <div>PaperContainer</div>;
+}

--- a/src/components/Paper/PaperContainer.jsx
+++ b/src/components/Paper/PaperContainer.jsx
@@ -1,3 +1,16 @@
+import * as S from './PaperContainer.style';
+import Paper from './Paper';
+
 export default function PaperContainer() {
-  return <div>PaperContainer</div>;
+  return (
+    <S.Wrapper>
+      <S.SlideContainer>
+        {/* 임시로 직접 4개 불러와봄 */}
+        <Paper />
+        <Paper />
+        <Paper />
+        <Paper />
+      </S.SlideContainer>
+    </S.Wrapper>
+  );
 }

--- a/src/components/Paper/PaperContainer.jsx
+++ b/src/components/Paper/PaperContainer.jsx
@@ -1,5 +1,7 @@
-import * as S from './PaperContainer.style';
+import leftArrow from '../../assetes/arrow_left.svg';
+import rightArrow from '../../assetes/arrow_right.svg';
 import Paper from './Paper';
+import * as S from './PaperContainer.style';
 
 export default function PaperContainer() {
   const mock = {
@@ -77,6 +79,9 @@ export default function PaperContainer() {
 
   return (
     <S.Wrapper>
+      <S.LeftArrowBox>
+        <S.Arrow src={leftArrow} alt="left-arrow" />
+      </S.LeftArrowBox>
       <S.SlideContainer>
         {/* 임시로 직접 4개 불러와봄 */}
         <Paper data={mock} />
@@ -84,6 +89,9 @@ export default function PaperContainer() {
         <Paper data={mock} />
         <Paper data={mock} />
       </S.SlideContainer>
+      <S.RightArrowBox>
+        <S.Arrow src={rightArrow} alt="right-arrow" />
+      </S.RightArrowBox>
     </S.Wrapper>
   );
 }

--- a/src/components/Paper/PaperContainer.jsx
+++ b/src/components/Paper/PaperContainer.jsx
@@ -2,14 +2,87 @@ import * as S from './PaperContainer.style';
 import Paper from './Paper';
 
 export default function PaperContainer() {
+  const mock = {
+    id: 1,
+    name: '강영훈',
+    backgroundColor: 'green',
+    backgroundImageURL: null,
+    createdAt: '2023-10-26T13:19:31.401765Z',
+    messageCount: 4,
+    recentMessages: [
+      {
+        id: 32,
+        recipientId: 2,
+        sender: '김하은',
+        profileImageURL:
+          'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8',
+        relationship: '가족',
+        content: '열심히 일하는 모습 멋있습니다.',
+        font: 'Pretendard',
+        createdAt: '2023-11-01T08:05:25.399056Z'
+      },
+      {
+        id: 30,
+        recipientId: 2,
+        sender: '이영준',
+        profileImageURL:
+          'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8',
+        relationship: '지인',
+        content: '항상 응원합니다',
+        font: 'Noto Sans',
+        createdAt: '2023-11-01T08:04:12.852691Z'
+      },
+      {
+        id: 33,
+        recipientId: 2,
+        sender: '이영준',
+        profileImageURL:
+          'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8',
+        relationship: '지인',
+        content: '항상 응원합니다',
+        font: 'Noto Sans',
+        createdAt: '2023-11-01T08:04:12.852691Z'
+      },
+      {
+        id: 34,
+        recipientId: 2,
+        sender: '이영준',
+        profileImageURL:
+          'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8',
+        relationship: '지인',
+        content: '항상 응원합니다',
+        font: 'Noto Sans',
+        createdAt: '2023-11-01T08:04:12.852691Z'
+      }
+    ],
+    reactionCount: 48,
+    topReactions: [
+      {
+        id: 27,
+        emoji: '😀',
+        count: 14
+      },
+      {
+        id: 31,
+        emoji: '🥹',
+        count: 11
+      },
+      {
+        id: 34,
+        emoji: '😄',
+        count: 17
+      }
+    ]
+  };
+
   return (
     <S.Wrapper>
       <S.SlideContainer>
         {/* 임시로 직접 4개 불러와봄 */}
-        <Paper />
-        <Paper />
-        <Paper />
-        <Paper />
+        <Paper data={mock} />
+        <Paper data={mock} />
+        <Paper data={mock} />
+        <Paper data={mock} />
       </S.SlideContainer>
     </S.Wrapper>
   );

--- a/src/components/Paper/PaperContainer.style.js
+++ b/src/components/Paper/PaperContainer.style.js
@@ -1,10 +1,40 @@
 import styled from 'styled-components';
 
-export const Wrapper = styled.div``;
+export const Wrapper = styled.div`
+  position: relative;
+`;
 
 export const SlideContainer = styled.div`
   display: flex;
   gap: 20px;
   max-width: 1160px;
   overflow: hidden;
+`;
+
+export const ArrowBox = styled.div`
+  position: absolute;
+  top: 110px;
+
+  background-color: white;
+  width: 40px;
+  height: 40px;
+  border: 1px solid #dadcdf;
+  border-radius: 50%;
+  box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const LeftArrowBox = styled(ArrowBox)`
+  left: -20px;
+`;
+export const RightArrowBox = styled(ArrowBox)`
+  right: -20px;
+`;
+
+export const Arrow = styled.img`
+  width: 16px;
+  height: 16px;
 `;

--- a/src/components/Paper/PaperContainer.style.js
+++ b/src/components/Paper/PaperContainer.style.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div``;
+
+export const SlideContainer = styled.div`
+  display: flex;
+  gap: 20px;
+  max-width: 1160px;
+  overflow: hidden;
+`;

--- a/src/pages/List.jsx
+++ b/src/pages/List.jsx
@@ -1,3 +1,12 @@
+import PaperBox from '../components/Paper/PaperBox';
+import * as S from './List.style';
+
 export default function List() {
-  return <div>List</div>;
+  return (
+    <S.Container>
+      <PaperBox title="인기 롤링 페이퍼 🔥" />
+      <PaperBox title="최근에 만든 롤링 페이퍼 ⭐️️" />
+      <S.Button>나도 만들어 보기</S.Button>
+    </S.Container>
+  );
 }

--- a/src/pages/List.style.js
+++ b/src/pages/List.style.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 20px;
+  width: 100%;
+  max-width: 1200px;
+`;
+
+export const Button = styled.button`
+  position: fixed;
+  bottom: 40px;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;

--- a/src/pages/List/List.jsx
+++ b/src/pages/List/List.jsx
@@ -1,4 +1,4 @@
-import PaperBox from '../components/Paper/PaperBox';
+import PaperBox from '../../components/Paper/PaperBox';
 import * as S from './List.style';
 
 export default function List() {

--- a/src/pages/List/List.style.js
+++ b/src/pages/List/List.style.js
@@ -15,4 +15,21 @@ export const Button = styled.button`
   bottom: 40px;
   left: 50%;
   transform: translate(-50%, -50%);
+
+  display: flex;
+  width: 280px;
+  padding: 14px 24px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 12px;
+  background: var(--Purple-600);
+
+  color: var(--white);
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 28px;
+  letter-spacing: -0.18px;
 `;

--- a/src/pages/List/List.style.js
+++ b/src/pages/List/List.style.js
@@ -32,4 +32,8 @@ export const Button = styled.button`
   font-weight: 600;
   line-height: 28px;
   letter-spacing: -0.18px;
+
+  &:hover {
+    background: var(--Purple-700);
+  }
 `;

--- a/src/router/router.jsx
+++ b/src/router/router.jsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom';
 import Home from '../pages/Home';
 import Layout from '../pages/Layout';
-import List from '../pages/List';
+import List from '../pages/List/List';
 import Post from '../pages/Post';
 
 const router = createBrowserRouter([

--- a/src/router/router.jsx
+++ b/src/router/router.jsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import Home from '../pages/Home';
-import Layout from '../pages/Layout';
+import Layout from '../components/Layout';
 import List from '../pages/List/List';
 import Post from '../pages/Post';
 


### PR DESCRIPTION
# Motivation
- mock 데이터를 이용해 대략적인 list 페이지 레이아웃을 생성했습니다.
- Paper 컴포넌트의 기본 스타일을 추가했습니다.


# Key Changes
- list 페이지의 전체 레이아웃 구조
- **_Paper_** 컴포넌트와 Paper의 리스트를 담는 **_PaperContainer_**, Paper Container와 그 title을 담는 **_PaperBox_** 컴포넌트를 생성
- '나도 만들어보기' 버튼 (floating 버튼) 생성

<img width="500" alt="image" src="https://github.com/Dev-Duke-Seo/rolling_team1/assets/127701092/77a4b6c6-2663-42a5-b8ef-378f4cdf0485">


# To Reviewers
- 버튼은 추후 공통 컴포넌트로 만든 후 수정하도록 하겠습니다.
- 대략적인 layout과 스타일만 작성했기 때문에, 컴포넌트 구조나 컴포넌트명,  네임드 컴포넌트 이름에서 틀린 부분이나 수정하면 좋을 것 같은 부분 알려주시면 감사하겠습니다!

