### PR TITLE
[Refactor] 정렬기능 수정 및 디자인 수정

### DIFF
--- a/src/apis/fetchData.js
+++ b/src/apis/fetchData.js
@@ -1,4 +1,4 @@
-const BASE_URL = 'https://rolling-api.vercel.app/3-1/'; // 추후 환경변수로 빼기
+const BASE_URL = 'https://rolling-api.vercel.app/'; // 추후 환경변수로 빼기
 
 /** BASE_URL + param 로 부터 데이터를 fetch해와서 responseBody를 반환하는 함수
  *

--- a/src/components/Paper/Button/ArrowButton.style.js
+++ b/src/components/Paper/Button/ArrowButton.style.js
@@ -5,7 +5,7 @@ export const ArrowBox = styled.div`
   top: 11rem;
   z-index: 2;
 
-  background-color: white;
+  background-color: rgba(255, 255, 255, 0.5);
   width: 4rem;
   height: 4rem;
   border: 0.1rem solid #dadcdf;
@@ -18,6 +18,12 @@ export const ArrowBox = styled.div`
   align-items: center;
 
   ${props => `${props.$isLeft} : -2rem`};
+
+  &:hover {
+    transition: all 0.3s;
+    transform: scale(1.1);
+    background-color: white;
+  }
 
   @media (max-width: 768px) {
     display: none;

--- a/src/components/Paper/Paper.jsx
+++ b/src/components/Paper/Paper.jsx
@@ -18,7 +18,7 @@ export default function Paper({ data }) {
       $backgroundImageURL={backgroundImageURL}
       $backgroundColor={backgroundColor}
     >
-      <S.PaperTitle>To. {name}</S.PaperTitle>
+      <S.PaperTitle $isWhite={backgroundImageURL}>To. {name}</S.PaperTitle>
       <ImageList recentMessages={recentMessages} messageCount={messageCount} />
       <MessageCount messageCount={messageCount} />
       <S.HorizonLine />

--- a/src/components/Paper/Paper.style.js
+++ b/src/components/Paper/Paper.style.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
+import { PAPER_COLOR_MAPPER } from '../../constants/colorMapper';
 
-/* color 부분 css 변수이름과 달라서 일시적으로 복잡하게 변환해놓음 - 추후 스타일 변수명 변경 제안 */
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -13,8 +13,8 @@ export const Wrapper = styled.div`
   ${({ $backgroundImageURL, $backgroundColor }) =>
     `${
       $backgroundImageURL
-        ? `background-image: linear-gradient(rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.55)), url(${$backgroundImageURL});`
-        : `background-color: var(--${$backgroundColor[0].toUpperCase() + $backgroundColor.slice(1)}-200)`
+        ? `background-image: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url(${$backgroundImageURL}); color:white;`
+        : `background-color: ${PAPER_COLOR_MAPPER[$backgroundColor]}`
     }`};
   background-repeat: no-repeat;
   background-size: cover;
@@ -24,7 +24,8 @@ export const Wrapper = styled.div`
 
   @media (min-width: 768px) {
     &:hover {
-      transform: translateY(-0.5rem);
+      filter: brightness(95%);
+      transition: all 0.2s;
     }
   }
 
@@ -45,6 +46,7 @@ export const PaperTitle = styled.span`
   font-family: Pretendard-Bold;
   font-size: 2.4rem;
   line-height: 3.6rem;
+  ${({ $isWhite }) => $isWhite && 'color: white;'}
 
   @media (max-width: 360px) {
     font-size: 1.8rem;

--- a/src/components/Paper/PaperBox.jsx
+++ b/src/components/Paper/PaperBox.jsx
@@ -1,4 +1,3 @@
-import getSortedData from '../../utils/getSortedData';
 import Wrapper from './PaperBox.style';
 import PaperContainer from './PaperContainer';
 
@@ -7,12 +6,11 @@ export default function PaperBox({ orderBy, paperData }) {
     messageCount: '인기 롤링 페이퍼 🔥',
     createdAt: '최근에 만든 롤링 페이퍼 ⭐️️'
   };
-  const sortedPaperData = [...getSortedData(orderBy, paperData)];
 
   return (
     <Wrapper>
       <span>{title[orderBy]}</span>
-      <PaperContainer paperData={sortedPaperData} />
+      <PaperContainer paperData={paperData} />
     </Wrapper>
   );
 }

--- a/src/pages/List/List.jsx
+++ b/src/pages/List/List.jsx
@@ -6,21 +6,36 @@ import * as S from './List.style';
 import Error from '../Error/Error';
 
 export default function List() {
-  const { data, isLoading, isError } = useFetchData('recipients/', 'GET');
+  const {
+    data: dataOrderByMessageCount,
+    isLoading: isLoadingMessageCount,
+    isError: isErrorMessageCount
+  } = useFetchData('3-1/recipients/?sort=like', 'GET');
+  const {
+    data: dataOrderByCreatedAt,
+    isLoading: isLoadingCreatedAt,
+    isError: isErrorCreatedAt
+  } = useFetchData('3-1/recipients/', 'GET');
 
-  if (isLoading) {
+  if (isLoadingMessageCount || isLoadingCreatedAt) {
     return <Skeleton />;
   }
 
-  if (isError) {
+  if (isErrorMessageCount || isErrorCreatedAt) {
     return <Error />;
   }
 
   return (
     <S.Wrapper>
       <S.Container>
-        <PaperBox orderBy="messageCount" paperData={data.results} />
-        <PaperBox orderBy="createdAt" paperData={data.results} />
+        <PaperBox
+          orderBy="messageCount"
+          paperData={dataOrderByMessageCount.results}
+        />
+        <PaperBox
+          orderBy="createdAt"
+          paperData={dataOrderByCreatedAt.results}
+        />
         <Link to="/post">
           <S.Button>나도 만들어 보기</S.Button>
         </Link>

--- a/src/pages/List/List.jsx
+++ b/src/pages/List/List.jsx
@@ -10,12 +10,12 @@ export default function List() {
     data: dataOrderByMessageCount,
     isLoading: isLoadingMessageCount,
     isError: isErrorMessageCount
-  } = useFetchData('3-1/recipients/?sort=like', 'GET');
+  } = useFetchData('3-1/recipients/?sort=like&limit=50', 'GET');
   const {
     data: dataOrderByCreatedAt,
     isLoading: isLoadingCreatedAt,
     isError: isErrorCreatedAt
-  } = useFetchData('3-1/recipients/', 'GET');
+  } = useFetchData('3-1/recipients/?limit=50', 'GET');
 
   if (isLoadingMessageCount || isLoadingCreatedAt) {
     return <Skeleton />;

--- a/src/utils/getSortedData.js
+++ b/src/utils/getSortedData.js
@@ -1,8 +1,0 @@
-const getSortedData = (orderBy, arrayToSort) =>
-  arrayToSort.sort((previous, next) =>
-    orderBy === 'createdAt'
-      ? new Date(next[orderBy]) - new Date(previous[orderBy])
-      : next[orderBy] - previous[orderBy]
-  );
-
-export default getSortedData;


### PR DESCRIPTION
# Motivation
- 정렬 최적화


# Key Changes
- 불필요했던 정렬함수를 없애고 api로 부터 정렬된 데이터를 불러와서 보여주도록 수정했습니다.
- 페이퍼에 hover하면 올라가는게 좀 이질감 느껴져서 그냥 아주살짝 어두워지는 효과로 바꿨습니다.
- URL객체로 확인해봤는데 host만 baseurl로 빼는게 좋을 것 같아서 커스텀 훅 부분에 BASE_URL에 3-1을 빼고 endpoint를 3-1부터 입력하도록 수정했습니다.

# To Reviewers
- 정렬기능 만들때 아무리 sort를 붙여도 안됐던게 데이터가 모두 같은 날짜에 생성됨 + 생성된 메세지도 모두 0개 여서 그랬던거 였군요..
- 처음부터 데이터 날짜다르게 여러개 만들어놨다면 캐러셀도 불편하게 길이로 안움직이구 offset같은걸로 페이지네이션할 수 있었을텐데.. 그렇다고 지금와서 하기엔 너무 할 일이 많아져버려서 다른 모든걸 끝내고 나서 시간있으면 수정시도해보도록 하겠슴다.. 
