### PR TITLE
[Feat] 롤링페이퍼에 이모지(리액션) 선택 할 수 있는 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "emoji-picker-react": "^4.7.4",
         "prettier": "^3.2.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -7194,6 +7195,20 @@
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
+    "node_modules/emoji-picker-react": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.7.4.tgz",
+      "integrity": "sha512-V9+zbmbs4dQ+FpoUkg7SzOenZ8YV7+F+S7E5Mds3oufw6nsBo/jTExSe8Sg9DyvCUzI/Da/eZET6UAUSO0Z+1w==",
+      "dependencies": {
+        "flairup": "0.0.32"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -8387,6 +8402,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flairup": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-0.0.32.tgz",
+      "integrity": "sha512-kqFDVgPXq714gyUtKp/nEkCg4vWpRni8pSWoPMU54pQNGqVEOfT+bBYgCyWFb5MygSh2q0wCWvcX6kyAus9C7g=="
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",
@@ -17089,16 +17109,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "emoji-picker-react": "^4.7.4",
     "prettier": "^3.2.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/Card/PostPageHeader.jsx
+++ b/src/components/Card/PostPageHeader.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import EmojiPicker from 'emoji-picker-react';
 import EmojiList from '../Common/EmojiList';
 import ImageList from '../Common/ImageList';
 import MessageCount from '../Common/MessageCount';
@@ -5,13 +7,31 @@ import * as S from './PostPageHeader.style';
 import arrowDown from '../../assets/images/arrow-down.svg';
 import shareIcon from '../../assets/images/share-icon.svg';
 import addEmoji from '../../assets/images/add-emoji-icon.svg';
+import fetchData from '../../apis/fetchData';
 
 export default function PostPageHeader({
+  recipientId,
   recentMessages,
   name,
   messageCount,
   topReactions
 }) {
+  const [isEmojiPickerShow, setIsEmojiPickerShow] = useState(false);
+  const [recentTopReactions, setRecentTopReactions] = useState(null);
+
+  const handleReactionClick = async event => {
+    const body = { emoji: event.emoji, type: 'increase' };
+    try {
+      await fetchData(`3-1/recipients/${recipientId}/reactions/`, 'POST', body);
+      const response = await fetchData(
+        `3-1/recipients/${recipientId}/reactions/?limit=3`
+      );
+      setRecentTopReactions(response.results);
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
   return (
     <S.BackgroundArea>
       <S.PaperTitle>To. {name}</S.PaperTitle>
@@ -22,9 +42,19 @@ export default function PostPageHeader({
         />
         <MessageCount messageCount={messageCount} />
         <S.HorizonLine $margin="1.6rem" />
-        <EmojiList topReactions={topReactions} />
+        <EmojiList topReactions={recentTopReactions || topReactions} />
         <img src={arrowDown} alt="arrow-down" style={{ margin: '0.6rem' }} />
-        <img src={addEmoji} alt="emoji-icon" />
+        <button
+          type="button"
+          onClick={() => setIsEmojiPickerShow(!isEmojiPickerShow)}
+        >
+          <img src={addEmoji} alt="emoji-icon" />
+        </button>
+        {isEmojiPickerShow && (
+          <S.EmojiPickerBox>
+            <EmojiPicker onEmojiClick={event => handleReactionClick(event)} />
+          </S.EmojiPickerBox>
+        )}
         <S.HorizonLine />
         <img src={shareIcon} alt="share-icon" />
       </S.PaperBox>

--- a/src/components/Card/PostPageHeader.jsx
+++ b/src/components/Card/PostPageHeader.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import EmojiPicker from 'emoji-picker-react';
 import EmojiList from '../Common/EmojiList';
 import ImageList from '../Common/ImageList';
@@ -8,6 +8,7 @@ import arrowDown from '../../assets/images/arrow-down.svg';
 import shareIcon from '../../assets/images/share-icon.svg';
 import addEmoji from '../../assets/images/add-emoji-icon.svg';
 import fetchData from '../../apis/fetchData';
+import useClickOutside from '../../hooks/useClickOutside';
 
 export default function PostPageHeader({
   recipientId,
@@ -18,6 +19,7 @@ export default function PostPageHeader({
 }) {
   const [isEmojiPickerShow, setIsEmojiPickerShow] = useState(false);
   const [recentTopReactions, setRecentTopReactions] = useState(null);
+  const emojiRef = useRef(null);
 
   const handleReactionClick = async event => {
     const body = { emoji: event.emoji, type: 'increase' };
@@ -32,6 +34,8 @@ export default function PostPageHeader({
     }
   };
 
+  useClickOutside(emojiRef, setIsEmojiPickerShow);
+
   return (
     <S.BackgroundArea>
       <S.PaperTitle>To. {name}</S.PaperTitle>
@@ -44,17 +48,19 @@ export default function PostPageHeader({
         <S.HorizonLine $margin="1.6rem" />
         <EmojiList topReactions={recentTopReactions || topReactions} />
         <img src={arrowDown} alt="arrow-down" style={{ margin: '0.6rem' }} />
-        <button
-          type="button"
-          onClick={() => setIsEmojiPickerShow(!isEmojiPickerShow)}
-        >
-          <img src={addEmoji} alt="emoji-icon" />
-        </button>
-        {isEmojiPickerShow && (
-          <S.EmojiPickerBox>
-            <EmojiPicker onEmojiClick={event => handleReactionClick(event)} />
-          </S.EmojiPickerBox>
-        )}
+        <div ref={emojiRef}>
+          <button
+            type="button"
+            onClick={() => setIsEmojiPickerShow(!isEmojiPickerShow)}
+          >
+            <img src={addEmoji} alt="emoji-icon" />
+          </button>
+          {isEmojiPickerShow && (
+            <S.EmojiPickerBox>
+              <EmojiPicker onEmojiClick={event => handleReactionClick(event)} />
+            </S.EmojiPickerBox>
+          )}
+        </div>
         <S.HorizonLine />
         <img src={shareIcon} alt="share-icon" />
       </S.PaperBox>

--- a/src/components/Card/PostPageHeader.style.js
+++ b/src/components/Card/PostPageHeader.style.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 export const BackgroundArea = styled.div`
+  position: relative;
   width: 1200px;
   display: flex;
   align-items: center;
@@ -32,4 +33,11 @@ export const HorizonLine = styled.div`
   height: 2.8rem;
   background-color: var(--gray-300);
   margin: auto ${props => `${props.$margin || 0}`};
+`;
+
+export const EmojiPickerBox = styled.div`
+  position: absolute;
+  top: 5.6rem;
+  right: 0;
+  z-index: 1;
 `;

--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+export default function useClickOutside(reference, setState) {
+  useEffect(() => {
+    const handleClickOutside = event => {
+      if (reference.current && !reference.current.contains(event.target)) {
+        setState(false);
+      }
+    };
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  });
+}

--- a/src/pages/Post/Post.jsx
+++ b/src/pages/Post/Post.jsx
@@ -68,6 +68,7 @@ export default function Post() {
   return (
     <S.Page>
       <PostPageHeader
+        recipientId={recipientId}
         recentMessages={recentMessage}
         name={recipientName}
         messageCount={cardCount}


### PR DESCRIPTION
# Motivation
- 이모지 클릭하면 추가되고 post요청을 날림과 동시에 get해와서 화면에 나타나도록 했습니다
- 모달에도 쓰실 수 도 있을 것 같아서 모달 또는 팝업 외 영역 누르면 닫히는 useClickOutside 훅을 빼놓았습니다.

# Key Changes
- emoji-picker-react 라이브러리 설치되었습니다
- post페이지에서 추가 누르면 이모지 피커나오고 거기서 이모지 누르면 바로 추가됩니다
- 이모지 피커 외의 영역을 누르면 닫힙니다
  
<img width="763" alt="image" src="https://github.com/Dev-Duke-Seo/rolling_team1/assets/127701092/319efb48-2fe5-4c75-87e0-36e00758bf1e">

# To Reviewers
- 인덕님 작업영역이랑 안 부딪히려고 최대한 한 파일에서만 코드를 짜서 리팩토링은 추후 할 예정입니다. 감안하고 봐주세요!
- 새로운 라이브러리 깔아서 pull 하고나서 npm i 꼭 하셔야 합니당
- 멘토님말대로 일단 코드가 비효율... 인것 같긴해도 돌아는 가도록 해야할 것 같아서 올립니다 하하.. 
